### PR TITLE
reuseIdentifier 리팩토링

### DIFF
--- a/PhotosApp/PhotosApp.xcodeproj/project.pbxproj
+++ b/PhotosApp/PhotosApp.xcodeproj/project.pbxproj
@@ -475,12 +475,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = PD6NDXJV23;
 				INFOPLIST_FILE = PhotosApp/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = Limwin.PhotosApp;
+				PRODUCT_BUNDLE_IDENTIFIER = Photo.Test;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -492,12 +493,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = PhotosApp/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = Limwin.PhotosApp;
+				PRODUCT_BUNDLE_IDENTIFIER = "";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/PhotosApp/PhotosApp/Info.plist
+++ b/PhotosApp/PhotosApp/Info.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSPhotoLibraryUsageDescription</key>
-	<string>사진을 보기 위해 사진 앱에 접근해야 합니다.</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>
@@ -22,6 +20,8 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>사진을 보기 위해 사진 앱에 접근해야 합니다.</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/PhotosApp/PhotosApp/Model/PhotoDataSource.swift
+++ b/PhotosApp/PhotosApp/Model/PhotoDataSource.swift
@@ -28,18 +28,20 @@ class PhotoDataSource: NSObject {
 
 extension PhotoDataSource: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-       return allPhotos.count
-   }
-   
-   func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-       let asset = self.allPhotos.object(at: indexPath.item)
-       let cell = collectionView.dequeueReusableCell(for: indexPath) as PhotoCell
-       
-       imageManager.requestImage(for: asset, targetSize: thumbnailSize, contentMode: .aspectFill, options: nil) { image, _ in
-               cell.setPhoto(image)
-       }
-       return cell
-   }
+        return allPhotos.count
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        let asset = self.allPhotos.object(at: indexPath.item)
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: PhotoCell.reuseIdentifier, for: indexPath) as? PhotoCell else {
+            return PhotoCell()
+        }
+        
+        imageManager.requestImage(for: asset, targetSize: thumbnailSize, contentMode: .aspectFill, options: nil) { image, _ in
+            cell.setPhoto(image)
+        }
+        return cell
+    }
 }
 
 extension PhotoDataSource: PHPhotoLibraryChangeObserver {

--- a/PhotosApp/PhotosApp/Util/UICollectionViewExtensions.swift
+++ b/PhotosApp/PhotosApp/Util/UICollectionViewExtensions.swift
@@ -14,7 +14,7 @@ protocol ReusableView {
 
 extension ReusableView {
     static var reuseIdentifier: String {
-        return "PhotoCell"
+        return String(describing: self)
     }
 }
 

--- a/PhotosApp/PhotosApp/Util/UICollectionViewExtensions.swift
+++ b/PhotosApp/PhotosApp/Util/UICollectionViewExtensions.swift
@@ -14,17 +14,8 @@ protocol ReusableView {
 
 extension ReusableView {
     static var reuseIdentifier: String {
-        return String(describing: self)
+        return "PhotoCell"
     }
 }
 
 extension UICollectionViewCell: ReusableView { }
-
-extension UICollectionView {
-    func dequeueReusableCell<T: UICollectionViewCell>(for indexPath: IndexPath) -> T {
-        guard let cell = dequeueReusableCell(withReuseIdentifier: T.reuseIdentifier, for: indexPath) as? T else {
-            fatalError("Could not dequeue cell with identifier: \(T.reuseIdentifier)")
-        }
-        return cell
-    }
-}

--- a/PhotosApp/PhotosApp/View/PhotoCell.swift
+++ b/PhotosApp/PhotosApp/View/PhotoCell.swift
@@ -11,8 +11,6 @@ import UIKit
 class PhotoCell: UICollectionViewCell {
     @IBOutlet weak var photoImageView: UIImageView!
     
-    var representedAssetIdentifier: String!
-    
     func setPhoto(_ image: UIImage?) {
         guard let image = image else { return }
         photoImageView.image = image

--- a/PhotosApp/PhotosApp/ViewController.swift
+++ b/PhotosApp/PhotosApp/ViewController.swift
@@ -23,7 +23,7 @@ class ViewController: UIViewController {
         collectionView.dataSource = collectionViewDataSource
         
         photoObserver = NotificationCenter.default.addObserver(forName: .photoDidChange) { [weak self] _ in
-            DispatchQueue.main.sync { self?.collectionView.reloadData() }
+            DispatchQueue.main.async { self?.collectionView.reloadData() }
         }
     }
     


### PR DESCRIPTION
- dequeueReusableCell extension 삭제
- reuseIdentifier를 "PhotoCell"로 설정해 ```PhotoCell.reuseIdentifier```로 사용하도록 변경했음.
- PhotoCell의 사용하지 않는 프로퍼티 삭제
- background오류로 sync -> async로 변경