### PR TITLE
Doodle View Controller 화면 셋업

### DIFF
--- a/PhotosApp/PhotosApp.xcodeproj/project.pbxproj
+++ b/PhotosApp/PhotosApp.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		AB0CB234241F434100396015 /* PhotosAppUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB0CB233241F434100396015 /* PhotosAppUITests.swift */; };
 		AB0CB244241F530300396015 /* PhotoCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB0CB243241F530300396015 /* PhotoCell.swift */; };
 		AB7CD9442420D6EC00392F6F /* PhotoDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB7CD9432420D6EC00392F6F /* PhotoDataSource.swift */; };
+		C231F8D92422420400494624 /* DoodleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C231F8D82422420400494624 /* DoodleViewController.swift */; };
 		C29035172422132D00E47CDC /* UIView+FillSuperView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C29035162422132D00E47CDC /* UIView+FillSuperView.swift */; };
 		C2949DD8242105C10037B1C6 /* UICollectionViewExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2949DD7242105C10037B1C6 /* UICollectionViewExtensions.swift */; };
 		C2949DDA2421CC7D0037B1C6 /* NotificationExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2949DD92421CC7D0037B1C6 /* NotificationExtensions.swift */; };
@@ -54,6 +55,7 @@
 		AB0CB235241F434100396015 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		AB0CB243241F530300396015 /* PhotoCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoCell.swift; sourceTree = "<group>"; };
 		AB7CD9432420D6EC00392F6F /* PhotoDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoDataSource.swift; sourceTree = "<group>"; };
+		C231F8D82422420400494624 /* DoodleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoodleViewController.swift; sourceTree = "<group>"; };
 		C29035162422132D00E47CDC /* UIView+FillSuperView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+FillSuperView.swift"; sourceTree = "<group>"; };
 		C2949DD7242105C10037B1C6 /* UICollectionViewExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UICollectionViewExtensions.swift; sourceTree = "<group>"; };
 		C2949DD92421CC7D0037B1C6 /* NotificationExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationExtensions.swift; sourceTree = "<group>"; };
@@ -113,6 +115,7 @@
 				AB0CB211241F433F00396015 /* AppDelegate.swift */,
 				AB0CB213241F433F00396015 /* SceneDelegate.swift */,
 				AB0CB215241F433F00396015 /* PhotoViewController.swift */,
+				C231F8D82422420400494624 /* DoodleViewController.swift */,
 				AB0CB21A241F434100396015 /* Assets.xcassets */,
 				AB0CB21C241F434100396015 /* LaunchScreen.storyboard */,
 				AB0CB21F241F434100396015 /* Info.plist */,
@@ -301,6 +304,7 @@
 				AB0CB212241F433F00396015 /* AppDelegate.swift in Sources */,
 				C2949DDA2421CC7D0037B1C6 /* NotificationExtensions.swift in Sources */,
 				C2949DD8242105C10037B1C6 /* UICollectionViewExtensions.swift in Sources */,
+				C231F8D92422420400494624 /* DoodleViewController.swift in Sources */,
 				AB0CB214241F433F00396015 /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/PhotosApp/PhotosApp/DoodleViewController.swift
+++ b/PhotosApp/PhotosApp/DoodleViewController.swift
@@ -14,5 +14,30 @@ class DoodleViewController: UICollectionViewController {
         super.viewDidLoad()
         title = "Doodles"
         collectionView.backgroundColor = .darkGray
+        setupBarButton()
+    }
+    
+    override init(collectionViewLayout layout: UICollectionViewLayout) {
+        super.init(collectionViewLayout: layout)
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+    
+    convenience init() {
+        self.init(collectionViewLayout: UICollectionViewFlowLayout())
+    }
+    
+    @objc private func dismissDoodles() {
+        dismiss(animated: true)
+    }
+    
+    private func setupBarButton() {
+        let button = UIBarButtonItem(title: "Close",
+                                     style: .plain,
+                                     target: self,
+                                     action: #selector(dismissDoodles))
+        navigationItem.rightBarButtonItem = button
     }
 }

--- a/PhotosApp/PhotosApp/DoodleViewController.swift
+++ b/PhotosApp/PhotosApp/DoodleViewController.swift
@@ -1,0 +1,18 @@
+//
+//  DoodleViewController.swift
+//  PhotosApp
+//
+//  Created by Chaewan Park on 2020/03/18.
+//  Copyright © 2020 임승혁. All rights reserved.
+//
+
+import UIKit
+
+class DoodleViewController: UICollectionViewController {
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "Doodles"
+        collectionView.backgroundColor = .darkGray
+    }
+}

--- a/PhotosApp/PhotosApp/PhotoViewController.swift
+++ b/PhotosApp/PhotosApp/PhotoViewController.swift
@@ -21,6 +21,8 @@ class PhotoViewController: UICollectionViewController {
         collectionView.dataSource = photoDataSource
         collectionView.register(PhotoCell.self, forCellWithReuseIdentifier: PhotoCell.reuseIdentifier)
         
+        setupBarButton()
+        
         let center = NotificationCenter.default
         photoObserver = center.addObserver(forName: .photoDidChange) { [weak self] notification in
             DispatchQueue.main.async { self?.updateCollectionView(with: notification.userInfo) }
@@ -30,6 +32,13 @@ class PhotoViewController: UICollectionViewController {
     deinit {
         guard let observer = photoObserver else { return }
         NotificationCenter.default.removeObserver(observer)
+    }
+    
+    @objc private func showDoodles() { }
+    
+    private func setupBarButton() {
+        let button = UIBarButtonItem(barButtonSystemItem: .add, target: self, action: #selector(showDoodles))
+        navigationItem.leftBarButtonItem = button
     }
     
     private func updateCollectionView(with changes: Dictionary<AnyHashable, Any>?) {

--- a/PhotosApp/PhotosApp/PhotoViewController.swift
+++ b/PhotosApp/PhotosApp/PhotoViewController.swift
@@ -29,12 +29,27 @@ class PhotoViewController: UICollectionViewController {
         }
     }
     
+    override init(collectionViewLayout layout: UICollectionViewLayout) {
+        super.init(collectionViewLayout: layout)
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+    
+    convenience init() {
+        self.init(collectionViewLayout: UICollectionViewFlowLayout())
+    }
+    
     deinit {
         guard let observer = photoObserver else { return }
         NotificationCenter.default.removeObserver(observer)
     }
     
-    @objc private func showDoodles() { }
+    @objc private func showDoodles() {
+        let nextViewController = UINavigationController(rootViewController: DoodleViewController())
+        present(nextViewController, animated: true)
+    }
     
     private func setupBarButton() {
         let button = UIBarButtonItem(barButtonSystemItem: .add, target: self, action: #selector(showDoodles))

--- a/PhotosApp/PhotosApp/SceneDelegate.swift
+++ b/PhotosApp/PhotosApp/SceneDelegate.swift
@@ -15,7 +15,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         if let windowScene = scene as? UIWindowScene {
             let window = UIWindow(windowScene: windowScene)
-            let rootViewController = PhotoViewController(collectionViewLayout: UICollectionViewFlowLayout())
+            let rootViewController = PhotoViewController()
             window.rootViewController = UINavigationController(rootViewController: rootViewController)
             self.window = window
             window.makeKeyAndVisible()

--- a/PhotosApp/PhotosApp/SceneDelegate.swift
+++ b/PhotosApp/PhotosApp/SceneDelegate.swift
@@ -24,4 +24,3 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let _ = (scene as? UIWindowScene) else { return }
     }
 }
-


### PR DESCRIPTION
이슈 #27 을 구현하였습니다.
* Doodle View Controller를 새로 추가하였습니다.
* 기존 VC와 Doodle VC에 각각 바 버튼 아이템을 추가하였습니다.
* 기존 VC와 Doodle VC 간 화면 전환을 구현하였습니다.
* 기존 VC와 Doodle VC 생성 시에 UICollectionViewLayout을 일일이 넣어주지 않기 위해 convenience init을 추가하였습니다.